### PR TITLE
Adding 'field' class to category setting section

### DIFF
--- a/assets/javascripts/discourse/templates/components/restrict-replies-setting.hbs
+++ b/assets/javascripts/discourse/templates/components/restrict-replies-setting.hbs
@@ -1,4 +1,4 @@
-<section class="restrict-replies">
+<section class="field restrict-replies">
   <h3>{{i18n "restricted_replies.title"}}</h3>
   <label>
     {{input type="checkbox" checked=category.custom_fields.restrict_replies}}


### PR DESCRIPTION
The `field` class is used on the category page to add padding to sections on the settings page. It's a very small change, but would make the category security page look better when there are other plugins loaded after this one.

Before:
![image](https://user-images.githubusercontent.com/4741093/126550625-0ec27609-6408-4444-b31c-8f71afafde68.png)

After:
![image](https://user-images.githubusercontent.com/4741093/126550675-dea72918-11d5-4217-adc8-082a6f957718.png)
